### PR TITLE
Update hero heading and background

### DIFF
--- a/images/m4-mac.svg
+++ b/images/m4-mac.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300">
+  <!-- Simple illustration of an M4 Mac with AI and DevOps stickers -->
+  <!-- screen -->
+  <rect x="50" y="20" width="400" height="220" rx="10" ry="10" fill="#d8d8d8" />
+  <!-- body base -->
+  <rect x="20" y="240" width="460" height="30" rx="5" ry="5" fill="#b0b0b0" />
+  <rect x="0" y="270" width="500" height="20" fill="#999999" />
+  <!-- trackpad -->
+  <rect x="225" y="250" width="50" height="15" fill="#777777" />
+  <!-- AI sticker -->
+  <rect x="120" y="60" width="60" height="40" fill="#ffdd33" />
+  <text x="150" y="85" font-size="20" text-anchor="middle" fill="#000">AI</text>
+  <!-- DevOps sticker -->
+  <rect x="320" y="150" width="80" height="40" fill="#80c3ff" />
+  <text x="360" y="175" font-size="20" text-anchor="middle" fill="#000">DevOps</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         /* Hero styles */
         .hero {
             background: linear-gradient(135deg, rgba(79, 70, 229, 0.7), rgba(147, 51, 234, 0.7)),
-                        url('https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1200&q=80');
+                        url('images/m4-mac.svg');
             background-attachment: fixed;
             background-size: cover;
             background-position: center;
@@ -52,11 +52,9 @@
             max-width: 700px;
         }
         .hero h1 {
-            font-size: 2.5rem;
+            font-size: 4rem;
             margin-bottom: 10px;
-            background: linear-gradient(90deg, #f79533, #f37055, #ef4e7b, #a166ab, #5073b8, #1098ad, #07b39b, #6fba82);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #ffffff;
         }
         .hero h2 {
             font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- update hero background to show a Mac with AI and DevOps stickers
- enlarge name heading and use a single color
- add new SVG illustration for the background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869111e3f3c832498fbcff2e8719631